### PR TITLE
Fixed errors in POD syntax

### DIFF
--- a/lib/Authen/SASL/Perl/DIGEST_MD5.pm
+++ b/lib/Authen/SASL/Perl/DIGEST_MD5.pm
@@ -802,7 +802,7 @@ in the initial response.
 
 =head3 server
 
-=over4
+=over 4
 
 =item realm
 

--- a/lib/Authen/SASL/Perl/LOGIN.pm
+++ b/lib/Authen/SASL/Perl/LOGIN.pm
@@ -172,7 +172,7 @@ The user's password to be used for authentication
 
 =head3 Server
 
-=over4
+=over 4
 
 =item getsecret(username)
 

--- a/lib/Authen/SASL/Perl/PLAIN.pm
+++ b/lib/Authen/SASL/Perl/PLAIN.pm
@@ -143,7 +143,7 @@ The user's password to be used for authentication.
 
 =head3 Server
 
-=over4
+=over 4
 
 =item checkpass(username, password, realm)
 


### PR DESCRIPTION
One of the problems flagged at http://cpants.cpanauthors.org/dist/Authen-SASL is the presence of some syntax errors in the POD. This PR fixes those and the dist now passes all_pod_files_ok() in Test::POD.

This work has been done as part of the [CPAN PR Challenge](http://cpan-prc.org/).
