### PR TITLE
Added README and changed perl minimum version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,7 @@ version_from	'lib/Authen/SASL.pm';
 license		'perl';
 repository	'http://github.com/gbarr/perl-authen-sasl';
 
-perl_version	5.005;
+perl_version	5.006;
 
 test_requires	'Test::More' => 0;
 requires	'Digest::MD5'  => 0;

--- a/README
+++ b/README
@@ -1,0 +1,36 @@
+Authen::SASL - SASL Authentication framework
+
+
+DESCRIPTION
+-----------
+
+SASL is a generic mechanism for authentication used by several network
+protocols. Authen::SASL provides an implementation framework that all
+protocols should be able to share.
+
+
+PREREQUISITES
+-------------
+
+The following modules must already be installed before attempting to
+build Authen::SASL:
+
+  * Perl, at least version 5.005
+  * Digest::MD5
+  * Digest::HMAC_MD5
+  * Test::More (only required to run the test suite)
+
+
+INSTALLING
+----------
+
+Once the prerequisites are met the module is built and installed in the
+standard manner:
+
+  perl Makefile.PL
+  make
+  make test
+  make install
+
+Depending on how perl is set up, the last step above may require elevated
+privileges.

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ PREREQUISITES
 The following modules must already be installed before attempting to
 build Authen::SASL:
 
-  * Perl, at least version 5.005
+  * Perl, at least version 5.6.0
   * Digest::MD5
   * Digest::HMAC_MD5
   * Test::More (only required to run the test suite)


### PR DESCRIPTION
http://cpants.cpanauthors.org/dist/Authen-SASL-2.16 complains that there is no README for the dist. This PR adds a basic README with just the name, description, prerequisites and installation instructions.

In constructing this I ran perlver to confirm the declared minumum version and found that it needed to be 5.6.0 rather than 5.005 because of the "our" declarations, so that has been changed as well.
