### PR TITLE
Test coverage enhancements

### DIFF
--- a/lib/Authen/SASL.pm
+++ b/lib/Authen/SASL.pm
@@ -124,7 +124,7 @@ sub initial {
 
 sub name {
   my $self = shift;
-  $self->{conn} ? $self->{conn}->mechanism : ($self->{mechanism} =~ /(\S+)/)[0];
+  $self->{conn} ? $self->{conn}->mechanism : (($self->{mechanism} || '') =~ /(\S+)/)[0];
 }
 
 1;

--- a/t/compat.t
+++ b/t/compat.t
@@ -1,0 +1,40 @@
+#!perl
+
+# Test of the methods marked "Compat" in Authen::SASL
+# Heavily based on the compat_pl script at the root level
+# (which this essentially replaces)
+
+use strict;
+use warnings;
+
+use Test::More tests => 8;
+
+use Authen::SASL;
+
+my $sasl = Authen::SASL->new('CRAM-MD5', password => 'fred');
+
+$sasl->user('foo');
+is ($sasl->user('gbarr'), 'foo', 'user method returns previous value');
+is ($sasl->user, 'gbarr', 'user method with no args returns value');
+
+my $initial = $sasl->initial;
+is ($initial, '', 'initial method returns empty string');
+my $mech = $sasl->name;
+is ($mech, 'CRAM-MD5', 'mech method returns mechanism');
+
+#print "$mech;", unpack("H*",$initial),";\n";
+
+#print unpack "H*", $sasl->challenge('xyz');
+is ((unpack "H*", $sasl->challenge('xyz')),
+  '6762617272203336633933316665343766336665396337616462663831306233633763346164',
+  "$mech challenge matches");
+
+$sasl = Authen::SASL->new(mech => 'CRAM-MD5', password => 'fred');
+$mech = $sasl->name;
+is ($mech, 'CRAM-MD5', 'constructor allows "mech" as first key');
+
+$sasl = Authen::SASL->new(foo => 'CRAM-MD5', password => 'fred');
+$mech = $sasl->name;
+is ($mech, undef, 'constructor with no mechanism at all');
+
+is ($sasl->error, undef, 'no errors');

--- a/t/cram_md5.t
+++ b/t/cram_md5.t
@@ -4,7 +4,7 @@ BEGIN {
   eval { require Digest::HMAC_MD5 }
 }
 
-use Test::More ($Digest::HMAC_MD5::VERSION ? (tests => 5) : (skip_all => 'Need Digest::HMAC_MD5'));
+use Test::More ($Digest::HMAC_MD5::VERSION ? (tests => 6) : (skip_all => 'Need Digest::HMAC_MD5'));
 
 use Authen::SASL qw(Perl);
 
@@ -29,4 +29,13 @@ is($conn->client_start, '', 'client_start');
 
 is($conn->client_step("xyz"), 'gbarr 36c931fe47f3fe9c7adbf810b3c7c4ad', 'client_step');
 
+$sasl = Authen::SASL->new(
+  mechanism => 'CRAM-MD5',
+  callback => {
+    pass => 'fred',
+    authname => 'none'
+  },
+);
+$conn = $sasl->client_new("ldap","localhost", "noplaintext noanonymous");
+is($conn->client_step("xyz"), ' 36c931fe47f3fe9c7adbf810b3c7c4ad', 'client_step no user');
 

--- a/t/external.t
+++ b/t/external.t
@@ -1,6 +1,6 @@
 #!perl
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 
 use Authen::SASL qw(Perl);
 
@@ -24,4 +24,6 @@ is($conn->client_start, 'gbarr', 'client_start');
 
 is($conn->client_step("xyz"),  undef, 'client_step');
 
-
+$sasl = Authen::SASL->new(mechanism => 'EXTERNAL');
+$conn = $sasl->client_new("ldap","localhost", "noplaintext");
+is ($conn->client_start, '', 'no user callback');

--- a/t/server/login.t
+++ b/t/server/login.t
@@ -72,7 +72,7 @@ sub is_failure {
 
 ok($ssasl = Authen::SASL->new( %params ), "new");
 $server = $ssasl->server_new("ldap","localhost");
-my $cb;
+undef $cb;
 $server->server_start("", sub { $cb = 1 });
 ok $cb, "callback called"; $cb = 0;
 $server->server_step("foo", sub { $cb = 1 });


### PR DESCRIPTION
There are some small changes to the test suite here which improve the coverage a little. The major part of this is the creation of t/compat.t based on the existing compat_pl script. The PR doesn't remove compat_pl yet to make it really easy to compare the two. If/when you're happy that none of the functionality has been lost there's probably no need to keep compat_pl in the dist.

The other changes are minor or cosmetic and are hopefully fairly self-explanatory but please ask if you are in any doubt about them.
