### PR TITLE
Fix for '.' not being in @INC as of Perl 5.25.11

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use 5.005;
+use lib '.';
 use inc::Module::Install;
 
 name		'Authen-SASL';

--- a/t/server/login.t
+++ b/t/server/login.t
@@ -72,7 +72,7 @@ sub is_failure {
 
 ok($ssasl = Authen::SASL->new( %params ), "new");
 $server = $ssasl->server_new("ldap","localhost");
-my $cb;
+undef $cb;
 $server->server_start("", sub { $cb = 1 });
 ok $cb, "callback called"; $cb = 0;
 $server->server_step("foo", sub { $cb = 1 });


### PR DESCRIPTION
Also removed an unsightly warning.