### PR TITLE
Add 'maxssf' option to the constructor, and to the Perl module client_new

### DIFF
--- a/lib/Authen/SASL.pm
+++ b/lib/Authen/SASL.pm
@@ -35,6 +35,7 @@ sub new {
     mechanism => $opt{mechanism} || $opt{mech},
     callback  => {},
     debug => $opt{debug},
+    maxssf => $opt{maxssf},
   }, $pkg;
 
   $self->callback(%{$opt{callback}}) if ref($opt{callback}) eq 'HASH';

--- a/lib/Authen/SASL.pod
+++ b/lib/Authen/SASL.pod
@@ -79,6 +79,14 @@ See the L<callback|/callback> method for details.
 Set the list of mechanisms to choose from.
 See the L<mechanism|/mechanism> method for details.
 
+=item maxssf =E<gt> VALUE
+
+Override the SASL Maximum Security Strength Factor to C<VALUE>. This is required
+to be 0 for non-standard server implementations (ie. Active Directory) that do not 
+support SASL-layer encryption or integrity on SSL/TLS-protected connections.
+
+The default value is 2**31 - 1 for the Perl module, and 255 for the XS module.
+
 =item debug =E<gt> VALUE
 
 Set the debug level bit-value to C<VALUE> 

--- a/lib/Authen/SASL/Perl.pm
+++ b/lib/Authen/SASL/Perl.pm
@@ -65,7 +65,9 @@ sub client_new {
   } split /[^-\w]+/, $parent->mechanism
     or croak "No SASL mechanism found\n";
 
-  $mpkg[0]->_init($self);
+  my $conn = $mpkg[0]->_init($self);
+  $conn->property('maxssf' => $parent->{maxssf}) if defined $parent->{maxssf};
+  return $conn;
 }
 
 sub _init_server {}


### PR DESCRIPTION
Active Directory requires maxssf be 0 when using TLS. While it's possible to hand Net::LDAP a client connection instead of a subclass of Authen::SASL, that doesn't work when multiple LDAP servers need to be defined (HOST has to be defined separately for each one). So the workaround of calling client_new and then conn->property{maxssf => <n>} doesn't work, and that also doesn't support Authen::SASL::XS which currently provides no mechanism to set maxssf