### PR TITLE
Allow mechanism classes to decline based on callbacks

### DIFF
--- a/lib/Authen/SASL/Perl.pm
+++ b/lib/Authen/SASL/Perl.pm
@@ -59,6 +59,7 @@ sub client_new {
   } grep {
     my $have = $have{$_} ||= (eval "require $_;" and $_->can('_secflags')) ? 1 : -1;
     $have > 0 and $_->_secflags(@sec) == @sec
+        and $_->_acceptable( %{$parent->callback} )
   } map {
     (my $mpkg = __PACKAGE__ . "::$_") =~ s/-/_/g;
     $mpkg;
@@ -70,6 +71,7 @@ sub client_new {
 
 sub _init_server {}
 
+sub _acceptable  { 1 }
 sub _order   { 0 }
 sub code     { defined(shift->{error}) || 0 }
 sub error    { shift->{error}    }


### PR DESCRIPTION
This PR adds the possibility for mechanism classes dynamically decline being selected for client authentication.

In principle, the mere existence of a mechanism-defining module in combination with availability on the server, means the mechanism will be considered available for use by `Authen::SASL::Perl`. The _secflags check allows mechanism classes to refine that selection based on the security requirement flags passed by the client. However, some mechanisms may be available only when the caller provides  additional data. One such example is SCRAM-SHA-1-PLUS, which authenticates with channel binding. As part of my SCRAM SASL bindings, I'm looking to implement the channel binding variant as well. Hence my request for inclusion of this PR. If you have better ways, please let me know.