### PR TITLE
Generate cnonce and nonce from system randomness

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,7 @@ build Authen::SASL:
     * Digest::MD5
     * JSON::PP
     * Test::More (for running tests only)
+  * Crypt::URandom
   * Digest::HMAC_MD5
   * GSSAPI (optional; for Kerberos v5 support)
 

--- a/lib/Authen/SASL/Perl/DIGEST_MD5.pm
+++ b/lib/Authen/SASL/Perl/DIGEST_MD5.pm
@@ -202,7 +202,7 @@ sub server_start {
 
   $self->{need_step} = 1;
   $self->{error}     = undef;
-  $self->{nonce}     = $NONCE? md5_hex($NONCE) : unpack('H32',urandom(16));
+  $self->{nonce}     = $NONCE ? md5_hex($NONCE) : unpack('H32',urandom(16));
 
   $self->init_sec_layer;
 
@@ -261,7 +261,7 @@ sub client_step {   # $self, $server_sasl_credentials
 
   my %response = (
     nonce        => $sparams{'nonce'},
-    cnonce       => $CNONCE? md5_hex($CNONCE) : unpack('H32',urandom(16)),
+    cnonce       => $CNONCE ? md5_hex($CNONCE) : unpack('H32',urandom(16)),
     'digest-uri' => $self->service . '/' . $self->host,
     # calc how often the server nonce has been seen; server expects "00000001"
     nc           => sprintf("%08d",     ++$self->{nonce_counts}{$sparams{'nonce'}}),

--- a/lib/Authen/SASL/Perl/DIGEST_MD5.pm
+++ b/lib/Authen/SASL/Perl/DIGEST_MD5.pm
@@ -10,6 +10,7 @@ package Authen::SASL::Perl::DIGEST_MD5;
 use strict;
 use warnings;
 use vars qw(@ISA $CNONCE $NONCE);
+use Crypt::URandom qw(urandom);
 use Digest::MD5 qw(md5_hex md5);
 use Digest::HMAC_MD5 qw(hmac_md5);
 
@@ -201,7 +202,7 @@ sub server_start {
 
   $self->{need_step} = 1;
   $self->{error}     = undef;
-  $self->{nonce}     = md5_hex($NONCE || join (":", $$, time, rand));
+  $self->{nonce}     = $NONCE? md5_hex($NONCE) : unpack('H32',urandom(16));
 
   $self->init_sec_layer;
 
@@ -260,7 +261,7 @@ sub client_step {   # $self, $server_sasl_credentials
 
   my %response = (
     nonce        => $sparams{'nonce'},
-    cnonce       => md5_hex($CNONCE || join (":", $$, time, rand)),
+    cnonce       => $CNONCE? md5_hex($CNONCE) : unpack('H32',urandom(16)),
     'digest-uri' => $self->service . '/' . $self->host,
     # calc how often the server nonce has been seen; server expects "00000001"
     nc           => sprintf("%08d",     ++$self->{nonce_counts}{$sparams{'nonce'}}),


### PR DESCRIPTION
This fixes CVE-2025-40918.