### PR TITLE
Add support for host and port in OAUTHBEARER string

### DIFF
--- a/lib/Authen/SASL/Perl/OAUTHBEARER.pm
+++ b/lib/Authen/SASL/Perl/OAUTHBEARER.pm
@@ -38,13 +38,24 @@ sub client_start {
     # * gs2-authzid `a=" {User} "`
     #
     # The second part are key value pairs containing host, port and auth as
-    # described in RFC7628.
+    # described in RFC7628. Host and port are optional and can be omitted.
     #
     # https://datatracker.ietf.org/doc/html/rfc5801
     # https://datatracker.ietf.org/doc/html/rfc7628
     my $username = $self->_call('user');
+    my $host     = $self->_call('host');
+    my $port     = $self->_call('port');
     my $token    = $self->_call('pass'); # OAuth 2.0 access token
-    my $auth_string = "n,a=$username,\001auth=Bearer $token\001\001";
+    my $auth_string;
+    if (defined $host && defined $port) {
+      $auth_string = "n,a=$username,\001host=$host\001port=$port\001auth=Bearer $token\001\001";
+    } elsif (defined $host) {
+      $auth_string = "n,a=$username,\001host=$host\001auth=Bearer $token\001\001";
+    } elsif (defined $port) {
+      $auth_string = "n,a=$username,\001port=$port\001auth=Bearer $token\001\001";
+    } else {
+      $auth_string = "n,a=$username,\001auth=Bearer $token\001\001";
+    }
 
     return $auth_string;
 }
@@ -75,6 +86,8 @@ Authen::SASL::Perl::OAUTHBEARER - OAUTHBEARER Authentication class
     mechanism => 'OAUTHBEARER',
     callback  => {
       user => $user,
+      host => $hostname, #optional
+      port => $port, #optional
       pass => $access_token
     },
   );
@@ -95,6 +108,14 @@ The callbacks used are:
 =item user
 
 The username to be used for authentication.
+
+=item host
+
+The hostname to which the client will connect to. It is optional and can be omitted.
+
+=item port
+
+The destination port that the client will connect to. It should be a decimal positive integer string without leading zeros. It is optional and can be omitted.
 
 =item pass
 

--- a/lib/Authen/SASL/Perl/OAUTHBEARER.pm
+++ b/lib/Authen/SASL/Perl/OAUTHBEARER.pm
@@ -7,6 +7,7 @@
 package Authen::SASL::Perl::OAUTHBEARER;
 
 use strict;
+use warnings;
 use vars qw(@ISA);
 use JSON::PP;
 

--- a/lib/Authen/SASL/Perl/XOAUTH2.pm
+++ b/lib/Authen/SASL/Perl/XOAUTH2.pm
@@ -7,6 +7,7 @@
 package Authen::SASL::Perl::XOAUTH2;
 
 use strict;
+use warnings;
 use vars qw(@ISA);
 use JSON::PP;
 


### PR DESCRIPTION
RFC7628 also allows adding host and port to the OAUTHBEARER string. Any server may choose to enforce this. Add support for the same.